### PR TITLE
Removing -flto from builder

### DIFF
--- a/builder/Dyn.pm
+++ b/builder/Dyn.pm
@@ -24,8 +24,8 @@ use File::stat;
 #
 my $libver;
 my $CFLAGS
-    = ' -DNDEBUG -DBOOST_DISABLE_ASSERTS -flto -O2 -ffast-math -funroll-loops -fno-align-functions -fno-align-loops';
-my $LDFLAGS = ' -flto';    # https://wiki.freebsd.org/LinkTimeOptimization
+    = ' -DNDEBUG -DBOOST_DISABLE_ASSERTS -O2 -ffast-math -funroll-loops -fno-align-functions -fno-align-loops';
+my $LDFLAGS = ' ';    # https://wiki.freebsd.org/LinkTimeOptimization
 #
 sub write_file {
     my ( $filename, $content ) = @_;


### PR DESCRIPTION
We benchmarked ~2-3% slower with link optimization on and the project isn't large enough to bother. And it tossed up spurious warnings like the one found here: https://stackoverflow.com/questions/72218980/gcc-v12-1-warning-about-serial-compilation